### PR TITLE
Render options are added to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ This can also be done via import statement, but try avoidig this way:
 import icon from './icon.svg?fill=red&raw=false';
 ```
 
+### `renderOptions` (optional)
+
+Overwrites [render options](https://github.com/posthtml/posthtml-render#options) which by default are the following:
+
+    {
+        singleTags: [
+            'circle',
+            'ellipse',
+            'line',
+            'path',
+            'polygon',
+            'polyline',
+            'rect',
+            'use'
+        ],
+        closingSingleTag: 'slash'
+    }
+    
+
 
 ## Important notes
 

--- a/lib/process.js
+++ b/lib/process.js
@@ -20,6 +20,13 @@ var defaultRenderOptions = {
    * @see https://github.com/posthtml/posthtml-render#singletags
    */
   singleTags: [
+    'circle',
+    'ellipse',
+    'line',
+    'path',
+    'polygon',
+    'polyline',
+    'rect',
     'use'
   ]
 };

--- a/lib/process.js
+++ b/lib/process.js
@@ -19,13 +19,6 @@ var renderOptions = {
    * @see https://github.com/posthtml/posthtml-render#singletags
    */
   singleTags: [
-    'circle',
-    'ellipse',
-    'line',
-    'path',
-    'polygon',
-    'polyline',
-    'rect',
     'use'
   ]
 };

--- a/lib/process.js
+++ b/lib/process.js
@@ -1,3 +1,4 @@
+var objectAssign = require('object-assign');
 var posthtml = require('posthtml');
 var parser = require('posthtml-parser');
 var render = require('posthtml-render');
@@ -13,7 +14,7 @@ var xmlParser = parser(({
   lowerCaseAttributeNames: false
 }));
 
-var renderOptions = {
+var defaultRenderOptions = {
   closingSingleTag: 'slash',
   /**
    * @see https://github.com/posthtml/posthtml-render#singletags
@@ -29,6 +30,9 @@ var renderOptions = {
  * @returns {Promise<String>}
  */
 function process(content, options) {
+  options = options || {};
+  var renderOptions = objectAssign({}, defaultRenderOptions, options.renderOptions);
+
   return posthtml([fillPlugin(options)])
     .process(content, {parser: xmlParser})
     .then(function (result) {

--- a/test/posthtmlPlugin.test.js
+++ b/test/posthtmlPlugin.test.js
@@ -99,5 +99,11 @@ describe('Plugin wrapper', () => {
       '<path fill="blue" />'
     );
 
+    test(
+      'should preserve nested tags',
+      {fill: 'red', renderOptions: { singleTags: ['animate'] }},
+      '<rect><animate /></rect>',
+      '<rect fill="red"><animate /></rect>'
+    )
   });
 });


### PR DESCRIPTION
I was unable to use `svg-fill-loader` to process SVG shapes with nested `animate` tags:
    
    <rect x="45" y="40" width="10" height="20" rx="5" ry="5" transform="rotate(0 50 50) translate(0 -40)">
        <animate attributeName="opacity" from="1" to="0" dur="0.4s" begin="0s" repeatCount="indefinite"/>
    </rect>

Due to `rect` shape is in [singleTags](https://github.com/posthtml/posthtml-render#singletags) array nested `animate` tag is missing in result output. Though [SMIL SVG animations are marked as deprecated](http://stackoverflow.com/q/30965580/506695) and I was able to use CSS animations instead, leaving nested tags would be useful for backward compatibility.

This pull request allows nested tags in SVG basic shape tags.