### PR TITLE
Minor README.md fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ module.exports = {
       },
       {
         test: /\.sass$/,
-        loaders: [
+        use: [
           'css-loader',
           'svg-fill-loader/encodeSharp', // <- encodeSharp loader should be defined BEFORE css-loader
           'sass-loader' // but after any other loaders which produces CSS


### PR DESCRIPTION
Forgot to change `loaders` to `use` according to [new loaders configuration](https://webpack.js.org/guides/migrating/#module-loaders-is-now-module-rules).