### PR TITLE
Added alternative for encodeSharp loader in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,24 @@ module.exports = {
 }
 ```
 
+#### Alternative approach using mixin
+You can also use mixin for this instead of webpack configuration:
+```
+@mixin apply-background-image($url, $color) {
+   $base-color: str-slice(inspect($color), 2);
+   background-image: unquote('url("' + $url + "?fill=%23" + $base-color +'")');
+ }
+```
+And use it like this:
+```
+$hex-color: #e6e6e6;
+.your-class {
+  ...
+  @include apply-background-image("../your/image.svg", $hex-color);
+  ...
+}
+```
+
 ### Using with resolve-url-loader
 
 If you're using resolve-url-loader for rewriting paths in SCSS/LESS/etc, keep in mind that it will remove query string by default for some reason 

--- a/README.md
+++ b/README.md
@@ -211,14 +211,14 @@ module.exports = {
 
 #### Alternative approach using mixin
 You can also use mixin for this instead of webpack configuration:
-```
+```scss
 @mixin apply-background-image($url, $color) {
    $base-color: str-slice(inspect($color), 2);
    background-image: unquote('url("' + $url + "?fill=%23" + $base-color +'")');
  }
 ```
 And use it like this:
-```
+```scss
 $hex-color: #e6e6e6;
 .your-class {
   ...


### PR DESCRIPTION
This loader is great but In our team all of the colors are hex so we couldn't really use it without escaping #.
And we already had a quite complex webpack configuration - so adding encodeSharp loader was too much of a work.
So we implemented micro mixin for this. 

I assume it may be useful for others.
